### PR TITLE
Added try except

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -71,6 +71,7 @@ class Docker(object):
             self.logger.critical(e)
             if '<html>' in str(e):
                 self.logger.debug("Docker api issue. Ignoring")
+                raise ConnectionError
             elif 'unauthorized' in str(e):
                 self.logger.critical("Invalid Credentials. Exiting")
                 exit(1)


### PR DESCRIPTION
Added a catch in the event an image was built locally and doesn't exist in a remote registry.

Then:

```
2019-01-13 19:00:12 : CRITICAL : dockerclient : 404 Client Error: Not Found ("pull access denied for test/test, repository does not exist or may require 'docker login'")
Traceback (most recent call last):
  File "/usr/local/bin/ouroboros", line 5, in <module>
    main()
  File "/usr/local/lib/python3.7/site-packages/pyouroboros/ouroboros.py", line 129, in main
    schedule.run_all()
  File "/usr/local/lib/python3.7/site-packages/schedule/__init__.py", line 500, in run_all
    default_scheduler.run_all(delay_seconds=delay_seconds)
  File "/usr/local/lib/python3.7/site-packages/schedule/__init__.py", line 93, in run_all
    self._run_job(job)
  File "/usr/local/lib/python3.7/site-packages/schedule/__init__.py", line 131, in _run_job
    ret = job.run()
  File "/usr/local/lib/python3.7/site-packages/schedule/__init__.py", line 411, in run
    ret = self.job_func()
  File "/usr/local/lib/python3.7/site-packages/pyouroboros/dockerclient.py", line 100, in update_containers
    if current_image.id != latest_image.id:
AttributeError: 'NoneType' object has no attribute 'id'
```

Now:

```
2019-01-13 15:19:03 : ERROR : dockerclient : 'NoneType' object has no attribute 'id'
```