### PR TITLE
Add logger error if an invalid enable tag value is set.

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -50,7 +50,10 @@ class Docker(object):
             if self.config.label_enable and ouro_label:
                 if ouro_label.lower() in ["true", "yes"]:
                     monitored_containers.append(container)
+                elif ouro_label.lower() in ["false", "no"]:
+                    continue
                 else:
+                    self.logger.error('Malformed container enable label value in container \"%s\" (\"%s\").', container.name, ouro_label)
                     continue
             elif not self.config.labels_only and self.config.monitor and container.name in self.config.monitor \
                     and container.name not in self.config.ignore:


### PR DESCRIPTION
I was a bit stumped why my containers weren't being updated, until I realized I had escaped the enable label incorrectly in my `docker-compose.yml` file. I had:

```
    labels:
      - com.ouroboros.enable="true"
```

Rather than the expected:

```
    labels:
      - com.ouroboros.enable=true
```

Which caused Ouroboros to silently ignore the container. This adds a check for the expected enable values, and logs a warning if the user supplied value doesn't match a valid option.