### PR TITLE
Carry over network config

### DIFF
--- a/pyouroboros/helpers.py
+++ b/pyouroboros/helpers.py
@@ -18,7 +18,9 @@ def set_properties(old, new, self_name=None):
         'host_config': old.attrs['HostConfig'],
         'labels': old.attrs['Config']['Labels'],
         'entrypoint': old.attrs['Config']['Entrypoint'],
-        'environment': old.attrs['Config']['Env']
+        'environment': old.attrs['Config']['Env'],
+        # networks are conigured later
+        'networking_config': None
     }
 
     return properties


### PR DESCRIPTION
Fixes #193  

I tested this fix in the following way:  
```shell
docker network create test --subnet=10.13.37.0/24 --gateway=10.13.37.1
docker run -d --name=test --network=test --ip=10.13.37.2 fedora:28 sleep 999999
docker network connect bridge test
docker inspect test > /tmp/before
docker run -it --rm --name=ouroboros --hostname=ouroboros -v /var/run/docker.sock:/var/run/docker.sock ouroboros-local-build --run-once --latest
docker inspect test > /tmp/after
diff -u /tmp/before /tmp/after
```

```diff
--- /tmp/before 2019-02-09 16:22:12.325148378 +0100
+++ /tmp/after  2019-02-09 16:22:47.741186003 +0100
@@ -159,15 +159,15 @@
         },
         "NetworkSettings": {
             "Bridge": "",
-            "SandboxID": "5fa60a839a782dc2bde025aff718bd033c4e26fcb7d535abe9872e786b2abeda",
+            "SandboxID": "5de9f6429a7c569f823fac8a3eacc3b57154adf79698a9d95d2ca2da3007d548",
             "HairpinMode": false,
             "LinkLocalIPv6Address": "",
             "LinkLocalIPv6PrefixLen": 0,
             "Ports": {},
-            "SandboxKey": "/var/run/docker/netns/5fa60a839a78",
+            "SandboxKey": "/var/run/docker/netns/5de9f6429a7c",
             "SecondaryIPAddresses": null,
             "SecondaryIPv6Addresses": null,
-            "EndpointID": "60d5f338e845f81c677966a6add138f73566c7355799937c92443f7108350a90",
+            "EndpointID": "b34e354ceef795d3c12a4e70bca8f4e980edc5cc2dbc1adfbb6fc7c761148a9e",
             "Gateway": "192.168.169.1",
             "GlobalIPv6Address": "fd4c:5f97:84be:b89e:0:242:c0a8:a902",
             "GlobalIPv6PrefixLen": 64,
@@ -177,11 +177,11 @@
             "MacAddress": "02:42:c0:a8:a9:02",
             "Networks": {
                 "bridge": {
-                    "IPAMConfig": {},
+                    "IPAMConfig": null,
                     "Links": null,
-                    "Aliases": [],
+                    "Aliases": null,
                     "NetworkID": "dff833bfdf56f2f3926a61564ea94f09df0afe4a8b157a51188d978be063f9f8",
-                    "EndpointID": "60d5f338e845f81c677966a6add138f73566c7355799937c92443f7108350a90",
+                    "EndpointID": "b34e354ceef795d3c12a4e70bca8f4e980edc5cc2dbc1adfbb6fc7c761148a9e",
                     "Gateway": "192.168.169.1",
                     "IPAddress": "192.168.169.2",
                     "IPPrefixLen": 24,
@@ -197,10 +197,11 @@
                     },
                     "Links": null,
                     "Aliases": [
-                        "5e26769ae4d8"
+                        "5e26769ae4d8",
+                        "2a3f7f510b3d"
                     ],
                     "NetworkID": "717de8744adee3253bb915dff0ba0dd6997351d8bf56ffd3ea81f710161fdbf3",
-                    "EndpointID": "2bcde90fb9157d7619ac237f48e9e138a91a7c9804b45f697c22ebc537871412",
+                    "EndpointID": "6309f6033b096409e7337971f1c068ff79989af343541c9f929fb312917e18d3",
                     "Gateway": "10.13.37.1",
                     "IPAddress": "10.13.37.2",
                     "IPPrefixLen": 24,
