### PR TITLE
Add Warning for label_enable not set while using labels_only

### DIFF
--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -112,6 +112,10 @@ class Config(object):
 
         if self.interval < 30:
             self.interval = 30
+        
+        # Setting lables only implies labels should be enabled.
+        if self.labels_only:
+            self.label_enable = True
 
         for option in ['docker_sockets', 'notifiers', 'monitor', 'ignore']:
             if isinstance(getattr(self, option), str):

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -113,9 +113,8 @@ class Config(object):
         if self.interval < 30:
             self.interval = 30
         
-        # Setting lables only implies labels should be enabled.
-        if self.labels_only:
-            self.label_enable = True
+        if self.labels_only and not self.label_enable:
+            self.logger.warning('labels_only enabled but not in use without label_enable')
 
         for option in ['docker_sockets', 'notifiers', 'monitor', 'ignore']:
             if isinstance(getattr(self, option), str):

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -80,8 +80,7 @@ def main():
 
     docker_group.add_argument('-M', '--labels-only', default=Config.labels_only, dest='LABELS_ONLY',
                               action='store_true', help='Only watch containers that utilize labels\n'
-                                                        'This allows a more strict compliance for environments\n'
-                                                        'Note: This implies --label-enable true'
+                                                        'This allows a more strict compliance for environments'
                                                         'DEFAULT: False')
 
     docker_group.add_argument('-c', '--cleanup', default=Config.cleanup, dest='CLEANUP', action='store_true',

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -80,7 +80,8 @@ def main():
 
     docker_group.add_argument('-M', '--labels-only', default=Config.labels_only, dest='LABELS_ONLY',
                               action='store_true', help='Only watch containers that utilize labels\n'
-                                                        'This allows a more strict compliance for environments'
+                                                        'This allows a more strict compliance for environments\n'
+                                                        'Note: This implies --label-enable true'
                                                         'DEFAULT: False')
 
     docker_group.add_argument('-c', '--cleanup', default=Config.cleanup, dest='CLEANUP', action='store_true',


### PR DESCRIPTION
I spend a few minutes confused because I set labels_only to true, expecting labels to work. However, it required labels_enable to be set to true as well.

I don't see a scenario where setting labels_only but not enabling labels makes sense, so the update simply sets labels_enable to true if labels_only is true.