### PR TITLE
Added image tag option

### DIFF
--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -8,7 +8,7 @@ class Config(object):
                'PROMETHEUS_PORT', 'NOTIFIERS', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'LATEST', 'CRON',
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
-               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM']
+               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM', 'IMAGE_TAG']
 
     hostname = environ.get('HOSTNAME')
     interval = 300
@@ -22,6 +22,7 @@ class Config(object):
     data_export = None
     log_level = 'info'
     latest = False
+    image_tag = None
     cleanup = False
     run_once = False
     dry_run = False
@@ -112,6 +113,9 @@ class Config(object):
 
         if self.interval < 30:
             self.interval = 30
+        
+        if self.latest:
+            self.image_tag = 'latest'
 
         for option in ['docker_sockets', 'notifiers', 'monitor', 'ignore']:
             if isinstance(getattr(self, option), str):

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -89,6 +89,9 @@ def main():
     docker_group.add_argument('-L', '--latest', default=Config.latest, dest='LATEST', action='store_true',
                               help='Check for latest image instead of pulling current tag')
 
+    docker_group.add_argument('-g', '--image-tag', default=Config.image_tag, dest='IMAGE_TAG',
+                              help='Check for specified tag, regardless of what is being used')
+
     docker_group.add_argument('-r', '--repo-user', default=Config.repo_user, dest='REPO_USER',
                               help='Private docker registry username\n'
                                    'EXAMPLE: foo@bar.baz')


### PR DESCRIPTION
I found that image.tags[0] in dockerclient.Container.pull() doesn't always return what I want. In my situation, I had a container that had a number of tags (one for every commit, as I tag them with the git commit hash), as well as the last and most actual tag (which was 'staging', because I switched to tagging my releases with a more readable tag halfway during implementation of ouroboros). This however caused the container to never update, as it picked the first tag always, which didn't make sense for me anymore.

This is most probably not an issue for most people. However, I can imagine that people (myself included) wouldn't mind an option to just set the tag to whatever they want. Hence this pull request.

Furthermore, while testing I ran into some issues, especially one that caused the latest_image to be None in dockerclient.Container.update() due to an unhandled ApiError when pulling. So I proposed a fix for that as well.