### PR TITLE
Start new container in detached mode

### DIFF
--- a/pyouroboros/helpers.py
+++ b/pyouroboros/helpers.py
@@ -4,6 +4,7 @@ def set_properties(old, new, self_name=None):
         'name': self_name if self_name else old.name,
         'hostname': old.attrs['Config']['Hostname'],
         'user': old.attrs['Config']['User'],
+        'detach': True,
         'domainname': old.attrs['Config']['Domainname'],
         'tty': old.attrs['Config']['Tty'],
         'ports': None if not old.attrs['Config'].get('ExposedPorts') else [


### PR DESCRIPTION
Fixes #221 

Previously the new container was started without detaching it, which makes no sence since ouroboros should not (and most likely can't) run containers in foreground mode.
This resulted in docker setting AttachStdout/Err to `true`.