### PR TITLE
Check all services by default on swarm mode

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -371,7 +371,7 @@ class Service(object):
 
         for service in services:
             ouro_label = service.attrs['Spec']['Labels'].get('com.ouroboros.enable')
-            if ouro_label.lower() in ["true", "yes"]:
+            if not self.config.label_enable or ouro_label.lower() in ["true", "yes"]:
                 monitored_services.append(service)
 
         self.data_manager.monitored_containers[self.socket] = len(monitored_services)


### PR DESCRIPTION
Why in the default mode, all containers are check by default and on the swarm mode we need to add labels by default?

That PR standardize the behavior between normal and swarm mode.