### PR TITLE
Notification update

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include pyouroboros/templates *

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -5,7 +5,7 @@ from pyouroboros.logger import BlacklistFilter
 
 class Config(object):
     options = ['INTERVAL', 'PROMETHEUS', 'DOCKER_SOCKETS', 'MONITOR', 'IGNORE', 'LOG_LEVEL', 'PROMETHEUS_ADDR',
-               'PROMETHEUS_PORT', 'NOTIFIERS', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
+               'PROMETHEUS_PORT', 'NOTIFIERS', 'NOTIFIER_SHORT_MESSAGE', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
                'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM']
@@ -45,6 +45,7 @@ class Config(object):
     influx_database = None
 
     notifiers = []
+    notifier_short_message = False
 
     def __init__(self, environment_vars, cli_args):
         self.cli_args = cli_args
@@ -91,7 +92,8 @@ class Config(object):
                     except ValueError as e:
                         print(e)
                 elif option in ['CLEANUP', 'RUN_ONCE', 'INFLUX_SSL', 'INFLUX_VERIFY_SSL', 'DRY_RUN', 'SWARM',
-                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY']:
+                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY',
+                                'NOTIFIER_SHORT_MESSAGE']:
                     if env_opt.lower() in ['true', 'yes']:
                         setattr(self, option.lower(), True)
                     elif env_opt.lower() in ['false', 'no']:

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -9,7 +9,7 @@ class Config(object):
                'PROMETHEUS_PORT', 'NOTIFIERS', 'TEMPLATE_FILE', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
-               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM']
+               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SKIP_START_NOTIF', 'SWARM']
 
     hostname = environ.get('HOSTNAME')
     interval = 300
@@ -46,6 +46,7 @@ class Config(object):
     influx_database = None
 
     notifiers = []
+    skip_start_notif = False
     template = None
     template_file = None
 
@@ -94,7 +95,8 @@ class Config(object):
                     except ValueError as e:
                         print(e)
                 elif option in ['CLEANUP', 'RUN_ONCE', 'INFLUX_SSL', 'INFLUX_VERIFY_SSL', 'DRY_RUN', 'SWARM',
-                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY']:
+                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY',
+                                'SKIP_START_NOTIF']:
                     if env_opt.lower() in ['true', 'yes']:
                         setattr(self, option.lower(), True)
                     elif env_opt.lower() in ['false', 'no']:

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -158,7 +158,7 @@ class Config(object):
                 self.template_file = dir_path.joinpath("pyouroboros/templates/services.j2")
             else:
                 self.template_file = dir_path.joinpath("pyouroboros/templates/containers.j2")
-    
+
         if Path(self.template_file).exists():
             with open(self.template_file) as f:
                 self.template = f.read()

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -1,7 +1,6 @@
 from os import environ
 from pathlib import Path
 from logging import getLogger
-import pkg_resources
 from pyouroboros.logger import BlacklistFilter
 
 

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -1,11 +1,13 @@
 from os import environ
+from pathlib import Path
 from logging import getLogger
+import pkg_resources
 from pyouroboros.logger import BlacklistFilter
 
 
 class Config(object):
     options = ['INTERVAL', 'PROMETHEUS', 'DOCKER_SOCKETS', 'MONITOR', 'IGNORE', 'LOG_LEVEL', 'PROMETHEUS_ADDR',
-               'PROMETHEUS_PORT', 'NOTIFIERS', 'NOTIFIER_SHORT_MESSAGE', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
+               'PROMETHEUS_PORT', 'NOTIFIERS', 'TEMPLATE_FILE', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
                'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM']
@@ -45,7 +47,8 @@ class Config(object):
     influx_database = None
 
     notifiers = []
-    notifier_short_message = False
+    template = None
+    template_file = None
 
     def __init__(self, environment_vars, cli_args):
         self.cli_args = cli_args
@@ -92,8 +95,7 @@ class Config(object):
                     except ValueError as e:
                         print(e)
                 elif option in ['CLEANUP', 'RUN_ONCE', 'INFLUX_SSL', 'INFLUX_VERIFY_SSL', 'DRY_RUN', 'SWARM',
-                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY',
-                                'NOTIFIER_SHORT_MESSAGE']:
+                                'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY']:
                     if env_opt.lower() in ['true', 'yes']:
                         setattr(self, option.lower(), True)
                     elif env_opt.lower() in ['false', 'no']:
@@ -149,5 +151,20 @@ class Config(object):
 
         if self.data_export != 'influxdb':
             self.influx_url, self.influx_port, self.influx_username, self.influx_password = None, None, None, None
+
+        # Load default template file
+        if not self.template_file:
+            dir_path = Path().absolute()
+            if self.swarm:
+                self.template_file = dir_path.joinpath("pyouroboros/templates/services.j2")
+            else:
+                self.template_file = dir_path.joinpath("pyouroboros/templates/containers.j2")
+    
+        if Path(self.template_file).exists():
+            with open(self.template_file) as f:
+                self.template = f.read()
+        else:
+            self.logger.critical("Template file %s not found", self.template_file)
+            exit(1)
 
         self.config_blacklist()

--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -306,7 +306,7 @@ class Container(BaseImageObject):
                 self.data_manager.add(label='all', socket=self.socket)
                 self.notification_manager.send(
                     ContainerUpdateMessage(
-                        self.config.hostname,
+                        self.config,
                         self.socket,
                         updateable,
                         self.data_manager
@@ -341,7 +341,7 @@ class Container(BaseImageObject):
         if updated_count > 0:
             self.notification_manager.send(
                 ContainerUpdateMessage(
-                    self.config.hostname,
+                    self.config,
                     self.socket,
                     updateable,
                     self.data_manager
@@ -447,7 +447,7 @@ class Service(BaseImageObject):
                     self.data_manager.add(label='all', socket=self.socket)
                     self.notification_manager.send(
                         ServiceUpdateMessage(
-                            self.config.hostname,
+                            self.config,
                             self.socket,
                             updated_service_tuples,
                             self.data_manager
@@ -464,7 +464,7 @@ class Service(BaseImageObject):
         if updated_service_tuples:
             self.notification_manager.send(
                 ServiceUpdateMessage(
-                    self.config.hostname,
+                    self.config,
                     self.socket,
                     updated_service_tuples,
                     self.data_manager

--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -380,7 +380,7 @@ class Service(BaseImageObject):
 
     def monitor_filter(self):
         """Return filtered service objects list"""
-        services = self.client.services.list(filters={'label': 'com.ouroboros.enable'})
+        services = self.client.services.list()
 
         monitored_services = []
 

--- a/pyouroboros/helpers.py
+++ b/pyouroboros/helpers.py
@@ -23,3 +23,9 @@ def set_properties(old, new, self_name=None):
     }
 
     return properties
+
+
+def remove_sha_prefix(digest):
+    if digest.startswith("sha256:"):
+        return digest[7:]
+    return digest

--- a/pyouroboros/notifiers.py
+++ b/pyouroboros/notifiers.py
@@ -26,14 +26,18 @@ class StartupMessage(BaseMessage):
 
 
 class ContainerUpdateMessage(BaseMessage):
-    def __init__(self, hostname, socket, container_tuples, data_manager):
+    def __init__(self, config, socket, container_tuples, data_manager):
         title = f'Ouroboros has updated containers!'
-        body_fields = [
-            f"Host/Socket: {hostname} / {socket.split('//')[1]}",
-            f"Containers Monitored: {data_manager.monitored_containers[socket]}",
-            f"Total Containers Updated: {data_manager.total_updated[socket]}",
-            f"Containers updated this pass: {len(container_tuples)}"
-        ]
+        body_fields = []
+        if not config.notifier_short_message:
+            body_fields.extend(
+                [
+                    f"Host/Socket: {config.hostname} / {socket.split('//')[1]}",
+                    f"Containers Monitored: {data_manager.monitored_containers[socket]}",
+                    f"Total Containers Updated: {data_manager.total_updated[socket]}",
+                    f"Containers updated this pass: {len(container_tuples)}"
+                ]
+            )
         body_fields.extend(
             [
                 "{} updated from {} to {}".format(
@@ -47,14 +51,18 @@ class ContainerUpdateMessage(BaseMessage):
 
 
 class ServiceUpdateMessage(BaseMessage):
-    def __init__(self, hostname, socket, service_tuples, data_manager):
+    def __init__(self, config, socket, service_tuples, data_manager):
         title = f'Ouroboros has updated services!'
-        body_fields = [
-            f"Host/Socket: {hostname}",
-            f"Services Monitored: {data_manager.monitored_containers[socket]}",
-            f"Total services Updated: {data_manager.total_updated[socket]}",
-            f"Services updated this pass: {len(service_tuples)}"
-        ]
+        body_fields = []
+        if not config.notifier_short_message:
+            body_fields.extend(
+                [
+                    f"Host/Socket: {config.hostname}",
+                    f"Services Monitored: {data_manager.monitored_containers[socket]}",
+                    f"Total services Updated: {data_manager.total_updated[socket]}",
+                    f"Services updated this pass: {len(service_tuples)}"
+                ]
+            )
         body_fields.extend(
             [
                 "{} updated from {} to {}".format(

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -64,8 +64,8 @@ def main():
                                  'EXAMPLE: -N discord://1234123412341234/jasdfasdfasdfasddfasdf '
                                  'mailto://user:pass@gmail.com')
 
-    core_group.add_argument('--notifier-short-message', default=Config.notifier_short_message, action='store_true',
-                            dest='NOTIFIER_SHORT_MESSAGE', help='To send notification messages less verbose')
+    core_group.add_argument('--template-file', nargs='+', default=Config.template_file, dest='TEMPLATE_FILE',
+                            help='Use a custom template for notification')
 
     docker_group = parser.add_argument_group("Docker", "Configuration of docker functionality")
     docker_group.add_argument('-m', '--monitor', nargs='+', default=Config.monitor, dest='MONITOR',

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -10,7 +10,7 @@ from pyouroboros.config import Config
 from pyouroboros import VERSION, BRANCH
 from pyouroboros.logger import OuroborosLogger
 from pyouroboros.dataexporters import DataManager
-from pyouroboros.notifiers import NotificationManager
+from pyouroboros.notifiers import NotificationManager, StartupMessage
 from pyouroboros.dockerclient import Docker, Container, Service
 
 
@@ -190,7 +190,7 @@ def main():
         now = datetime.now(timezone.utc).astimezone()
         next_run = (now + timedelta(0, config.interval)).strftime("%Y-%m-%d %H:%M:%S")
 
-    notification_manager.send(kind='startup', next_run=next_run)
+    notification_manager.send(StartupMessage(config.hostname, next_run=next_run))
 
     while scheduler.get_jobs():
         sleep(1)

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -64,6 +64,9 @@ def main():
                                  'EXAMPLE: -N discord://1234123412341234/jasdfasdfasdfasddfasdf '
                                  'mailto://user:pass@gmail.com')
 
+    core_group.add_argument('--notifier-short-message', default=Config.notifier_short_message, action='store_true',
+                            dest='NOTIFIER_SHORT_MESSAGE', help='To send notification messages less verbose')
+
     docker_group = parser.add_argument_group("Docker", "Configuration of docker functionality")
     docker_group.add_argument('-m', '--monitor', nargs='+', default=Config.monitor, dest='MONITOR',
                               help='Which container(s) to monitor\n'

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -64,6 +64,9 @@ def main():
                                  'EXAMPLE: -N discord://1234123412341234/jasdfasdfasdfasddfasdf '
                                  'mailto://user:pass@gmail.com')
 
+    core_group.add_argument('--skip-start-notif', default=Config.dry_run, action='store_true', dest='SKIP_START_NOTIF',
+                            help='Skip notification of ouroboros has started')
+
     core_group.add_argument('--template-file', nargs='+', default=Config.template_file, dest='TEMPLATE_FILE',
                             help='Use a custom template for notification')
 
@@ -194,7 +197,8 @@ def main():
         now = datetime.now(timezone.utc).astimezone()
         next_run = (now + timedelta(0, config.interval)).strftime("%Y-%m-%d %H:%M:%S")
 
-    notification_manager.send(StartupMessage(config.hostname, next_run=next_run))
+    if not config.skip_start_notif:
+        notification_manager.send(StartupMessage(config.hostname, next_run=next_run))
 
     while scheduler.get_jobs():
         sleep(1)

--- a/pyouroboros/templates/containers.j2
+++ b/pyouroboros/templates/containers.j2
@@ -1,0 +1,7 @@
+Host/Socket: {{ hostname }} / {{ socket }}
+Containers Monitored: {{ total_monitored }}
+Total Containers Updated: {{ total_updated }}
+Containers updated this pass: {{ updated_tuples|length }}
+{% for container, old_image_id, new_image_id in updated_tuples %}
+ {{ container }} updated from {{ old_image_id }} to {{ new_image_id }}
+{% endfor %}

--- a/pyouroboros/templates/services.j2
+++ b/pyouroboros/templates/services.j2
@@ -1,0 +1,7 @@
+Host: {{ hostname }}
+Services Monitored: {{ total_monitored }}
+Total Services Updated: {{ total_updated }}
+Services updated this pass: {{ updated_tuples|length }}
+{% for service, old_image_sha, new_image_sha in updated_tuples %}
+ {{ service.name }} updated from {{ old_image_sha }} to {{ new_image_sha }}
+{% endfor %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.21.0
 influxdb>=5.2.1
 apprise>=0.5.2
 apscheduler>=3.5.3
+jinja2>=2.10

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
                  'Programming Language :: Python :: 3.6',
                  'Programming Language :: Python :: 3.7'],
     packages=find_packages(),
+    include_package_data=True,
     scripts=['ouroboros'],
     install_requires=get_requirements(),
     python_requires='>=3.6.2'


### PR DESCRIPTION
Hi,
Here a big change on notifications but there are no breaking changes. There are two goals:

### Add possibility to edit the notification message
Apprise is good to customize the notification service to use, but we need a way to customize the message. To do that I add templating message with jinja2 and an option template_file.

By default, if you don't specify template_file option, we use a default template depending if your running in container or swarm mode. If you add template_file option (don't forget to mount the file or the config in ouroboros container) that template is use. Available tokens for template are : hostname, socket, total_monitored, total_updated, updated_tuples, updated_tuples.

### Override notifiers for a container or service
You can use the label `com.ouroboros.notifiers` to override default notifiers only for this container/service.

Use case:
I use slack notification. I want all notification come to #devops channel, but for stack B I want to notify team B and for stack C I want to turn off notification.

To try I use this stack:
```
version: "3.6"

configs:
  ouroboros-template:
    file: template.j2

services:
  ouroboros:
    image: pyouroboros/ouroboros
    environment: 
      NOTIFIERS: "slack://${SLACK_TOKEN}/#devops-monitoring"
      TZ: "America/Montreal"
      TEMPLATE_FILE: "/template.j2"
      SWARM: "true"
    configs:
      - source: ouroboros-template
        target: /template.j2
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock
```

With this template file:
```

{% for service, old_image, new_image in updated_tuples %}
    {{ service.name }} updated from {{ old_image }} to {{ new_image }}
{% endfor %}
```

And I use this stack to try it:
```
version: "3.6"

services:
  testA:
    image: myorg/testimage

  testB:
    image: myorg/testimage
    deploy:
      labels:
        com.ouroboros.notifiers: "slack://${SLACK_TOKEN}/#devops-monitoring slack://${SLACK_TOKEN}/#teamB"

  testC:
    image: myorg/testimage
    deploy:
      labels:
        com.ouroboros.notifiers: ""
```

On update testA will send notification to channel devops-monitoring , testB on channel devops-monitoring  and teamB, and testC will not send notification.

Of course that work also with container without swarm mode:
```
docker run -d -it --label com.ouroboros.notifiers="" myorg/testimage
```

I'm open for any comment and review.