### PR TITLE
Fixing filter when labeling is disabled

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -389,7 +389,8 @@ class Service(BaseImageObject):
 
     def monitor_filter(self):
         """Return filtered service objects list"""
-        services = self.client.services.list(filters={'label': 'com.ouroboros.enable'})
+        filter = {'label': 'com.ouroboros.enable'} if self.config.label_enable else None
+        services = self.client.services.list(filters=filter)
 
         monitored_services = []
 


### PR DESCRIPTION
Hello,
I am using docker swarm and I have deployed the Ouroboros.
It doesnt do anything because we dont use ouroboros labes and they are filtered by default.
In service logs of Swarm I can see: `No services monitored`
I believe it is because in Service class the services are filtered no matter what the config is (refering to https://github.com/pyouroboros/ouroboros/wiki/Usage#label-enable).
This pull request should fix it