### PR TITLE
Align metric exposition with prometheus best practices

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -442,18 +442,14 @@ class Service(BaseImageObject):
                 )
 
                 if 'ouroboros' in service.name and self.config.self_update:
-                    self.data_manager.total_updated[self.socket] += 1
                     self.data_manager.add(label=service.name, socket=self.socket)
-                    self.data_manager.add(label='all', socket=self.socket)
                     self.notification_manager.send(container_tuples=updated_service_tuples,
                                                    socket=self.socket, kind='update', mode='service')
 
                 self.logger.info('%s will be updated', service.name)
                 service.update(image=f"{tag}@sha256:{latest_image_sha256}")
 
-                self.data_manager.total_updated[self.socket] += 1
                 self.data_manager.add(label=service.name, socket=self.socket)
-                self.data_manager.add(label='all', socket=self.socket)
 
         if updated_service_tuples:
             self.notification_manager.send(


### PR DESCRIPTION
This PR does couple of things.

1) Implement common naming schema for updating metrics in DataManager (allows to implement common interface for influx and prometheus without distinguishing it at every execution)

2) Implicitly update metric responsible for number of all updated containers.

3) Implements some fixes to prometheus exposed metrics and aligns them with [prometheus best practices](https://prometheus.io/docs/practices/naming/#metric-names). Mainly it namespaces metric names with application name.

4) Removes `all_containers_updated` gauge. This metric can be simply replaced by a counter as it is only going up. In such case application can reuse already present counter holding number of updated containers.

Applying this patch should result in exposing metrics as follows:
```
# HELP ouroboros_containers_updated_total Number of containers updated
# TYPE ouroboros_containers_updated_total counter
ouroboros_containers_updated_total{container="monitoring_grafana_1",socket="unix://var/run/docker.sock"} 1.0
ouroboros_containers_updated_total{container="",socket="unix://var/run/docker.sock"} 1.0

# TYPE ouroboros_containers_updated_created gauge
ouroboros_containers_updated_created{container="monitoring_grafana_1",socket="unix://var/run/docker.sock"} 1.558525377606453e+09
ouroboros_containers_updated_created{container="",socket="unix://var/run/docker.sock"} 1.558525377606453e+09

# HELP ouroboros_containers_monitored Number of monitored containers
# TYPE ouroboros_containers_monitored gauge
ouroboros_containers_monitored{socket="unix://var/run/docker.sock"} 6.0
```