### PR TITLE
Specify that we provide TEXT instead of MD or HTML

### DIFF
--- a/pyouroboros/notifiers.py
+++ b/pyouroboros/notifiers.py
@@ -60,4 +60,4 @@ class NotificationManager(object):
         body = '\r\n'.join(body_fields)
 
         if self.apprise.servers:
-            self.apprise.notify(title=title, body=body, body_format=apprise.common.NotifyFormat.TEXT)
+            self.apprise.notify(title=title, body=body, body_format=apprise.NotifyFormat.TEXT)

--- a/pyouroboros/notifiers.py
+++ b/pyouroboros/notifiers.py
@@ -60,4 +60,4 @@ class NotificationManager(object):
         body = '\r\n'.join(body_fields)
 
         if self.apprise.servers:
-            self.apprise.notify(title=title, body=body)
+            self.apprise.notify(title=title, body=body, body_format=apprise.common.NotifyFormat.TEXT)


### PR DESCRIPTION
As the lines are joined by simple line-breaks, we should let Apprise know that it is text. If one of the outgoing providers wants HTML, Apprise will then care of correct formatting, as was the case in issue #347