### PR TITLE
added webhook to check for updates, useful for CI jobs

### DIFF
--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -9,7 +9,8 @@ class Config(object):
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
                'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM', 'SKIP_STARTUP_NOTIFICATIONS',
-               'WEBHOOK', 'WEBHOOK_ADDR', 'WEBHOOK_PORT']
+               'WEBHOOK', 'WEBHOOK_ADDR', 'WEBHOOK_PORT', 'WEBHOOK_INSECURE',
+               'WEBHOOK_CERT', 'WEBHOOK_KEY', 'WEBHOOK_CACERT', 'WEBHOOK_USERS']
 
     hostname = environ.get('HOSTNAME')
     interval = 300
@@ -47,7 +48,12 @@ class Config(object):
 
     webhook = False
     webhook_addr = '127.0.0.1'
-    webhook_port = 8080
+    webhook_port = 8443
+    webhook_insecure = False
+    webhook_cert = ''
+    webhook_key = ''
+    webhook_cacert = None
+    webhook_users = None
 
     notifiers = []
     skip_startup_notifications = False
@@ -98,7 +104,7 @@ class Config(object):
                         print(e)
                 elif option in ['CLEANUP', 'RUN_ONCE', 'INFLUX_SSL', 'INFLUX_VERIFY_SSL', 'DRY_RUN', 'SWARM',
                                 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY', 'DOCKER_TLS_VERIFY',
-                                'SKIP_STARTUP_NOTIFICATIONS']:
+                                'SKIP_STARTUP_NOTIFICATIONS', 'WEBHOOK_INSECURE']:
                     if env_opt.lower() in ['true', 'yes']:
                         setattr(self, option.lower(), True)
                     elif env_opt.lower() in ['false', 'no']:

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -148,7 +148,10 @@ class Config(object):
                               "influxdb data export.")
 
         if self.data_export == 'prometheus' and self.self_update:
-            self.logger.warning("If you bind a port to ouroboros, it will be lost when it updates itself.")
+            self.logger.warning("If you bind a port for prometheus to ouroboros, it will be lost when it updates itself.")
+
+        if self.webhook and self.self_update:
+            self.logger.warning("If you bind a port for the webhook to ouroboros, it will be lost when it updates itself.")
 
         if self.dry_run and not self.run_once:
             self.logger.warning("Dry run is designed to be ran with run once. Setting for you.")

--- a/pyouroboros/config.py
+++ b/pyouroboros/config.py
@@ -8,7 +8,8 @@ class Config(object):
                'PROMETHEUS_PORT', 'NOTIFIERS', 'REPO_USER', 'REPO_PASS', 'CLEANUP', 'RUN_ONCE', 'CRON',
                'INFLUX_URL', 'INFLUX_PORT', 'INFLUX_USERNAME', 'INFLUX_PASSWORD', 'INFLUX_DATABASE', 'INFLUX_SSL',
                'INFLUX_VERIFY_SSL', 'DATA_EXPORT', 'SELF_UPDATE', 'LABEL_ENABLE', 'DOCKER_TLS', 'LABELS_ONLY',
-               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM', 'SKIP_STARTUP_NOTIFICATIONS']
+               'DRY_RUN', 'HOSTNAME', 'DOCKER_TLS_VERIFY', 'SWARM', 'SKIP_STARTUP_NOTIFICATIONS',
+               'WEBHOOK', 'WEBHOOK_ADDR', 'WEBHOOK_PORT']
 
     hostname = environ.get('HOSTNAME')
     interval = 300
@@ -43,6 +44,10 @@ class Config(object):
     influx_username = 'root'
     influx_password = 'root'
     influx_database = None
+
+    webhook = False
+    webhook_addr = '127.0.0.1'
+    webhook_port = 8080
 
     notifiers = []
     skip_startup_notifications = False

--- a/pyouroboros/ouroboros.py
+++ b/pyouroboros/ouroboros.py
@@ -146,7 +146,25 @@ def main():
 
     hook_group.add_argument('--webhook-port', type=int, default=Config.webhook_port, dest='WEBHOOK_PORT',
                             help='Port to run Webhook exporter on\n'
-                                 'DEFAULT: 8080')
+                                 'DEFAULT: 8443')
+
+    hook_group.add_argument('--webhook-insecure', default=Config.webhook_insecure, dest='WEBHOOK_INSECURE', action='store_true',
+                            help='Run webhook without TLS\n'
+                                 'DEFAULT: false')
+
+    hook_group.add_argument('--webhook-cert', default=Config.webhook_cert, dest='WEBHOOK_CERT',
+                            help='Certificate to use for webhook server')
+
+    hook_group.add_argument('--webhook-key', default=Config.webhook_key, dest='WEBHOOK_KEY',
+                            help='Key to use for webhook server')
+
+    hook_group.add_argument('--webhook-cacert', default=Config.webhook_cacert, dest='WEBHOOK_CACERT',
+                            help='CA Certificate for client verification on the webhook server')
+
+    hook_group.add_argument('--webhook-users', nargs='+', default=Config.webhook_users, dest='WEBHOOK_USERS',
+                            help='Authorized Client CNs\n'
+                                 'DEFAULT: ALL')
+
     args = parser.parse_args()
 
     if environ.get('LOG_LEVEL'):

--- a/pyouroboros/webhook.py
+++ b/pyouroboros/webhook.py
@@ -1,28 +1,70 @@
-from bottle import Bottle
-
 from logging import getLogger
 import threading
+import json, ssl
+
+from http.server import BaseHTTPRequestHandler, HTTPStatus, ThreadingHTTPServer
+
+
+class HookHandler(BaseHTTPRequestHandler):
+
+    def do_POST(self):
+        if self.server.config.webhook_insecure:
+            resp = {"status": "success", "path": self.path}
+            status = HTTPStatus.OK
+
+            for mode in self.server.config.modes:
+                self.server.config.scheduler.add_job(mode.update, name=f'Webhook triggered update for {mode.socket}')
+        else:
+            try:
+                if self.server.config.webhook_users is not None:
+                    c = self.request.getpeercert()
+                    cn=list(filter(lambda x: x[0][0] == "commonName", c["subject"]))
+                    if len(cn) == 1:
+                        if cn[0][0][1] not in self.server.config.webhook_users:
+                            raise Exception("Unauthorized")
+                    else:
+                        raise Exception("Malformed Cert")
+            except Exception as e:
+                resp = {"status":"unauthorized"}
+                status = HTTPStatus.UNAUTHORIZED
+            else:
+                resp = {"status": "success", "path": self.path}
+                status = HTTPStatus.OK
+
+                for mode in self.server.config.modes:
+                    self.server.config.scheduler.add_job(mode.update, name=f'Webhook triggered update for {mode.socket}')
+                #return 'updated'
+
+        dresp = json.dumps(resp).encode("utf8")
+        self.send_response(status)
+        self.send_header("Content-type", "application/json; charset=utf8")
+        self.send_header("Content-Length", str(len(dresp)))
+        self.end_headers()
+        self.wfile.write(dresp)
 
 
 class HookManager(object):
+
+    def serve(self, config):
+        httpd = ThreadingHTTPServer((config.webhook_addr, config.webhook_port), HookHandler)
+        if not config.webhook_insecure:
+            args = {}
+            if config.webhook_cacert:
+                args = {"cert_reqs": ssl.CERT_REQUIRED, "ca_certs": config.webhook_cacert}
+            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=config.webhook_cert, keyfile=config.webhook_key, ssl_version=ssl.PROTOCOL_TLSv1_2,
+                                           server_side=True, **args)
+
+        httpd.config = config
+        httpd.serve_forever()
+
     def __init__(self, config, modes, scheduler):
         self.config = config
         self.logger = getLogger()
         if not config.webhook:
             return
-        self.modes = modes
-        self.scheduler = scheduler
 
-        self._app = Bottle()
-        self._route()
+        self.config.scheduler = scheduler
+        self.config.modes = modes
 
-        threading.Thread(target=self._app.run, kwargs=dict(host=self.config.webhook_addr, port=self.config.webhook_port), daemon=True).start()
-
-    def _route(self):
-        self._app.route('/update', method="POST", callback=self._index)
-
-    def _index(self):
-        for mode in self.modes:
-            self.scheduler.add_job(mode.update, name=f'Webhook triggered update for {mode.socket}')
-        return 'updated'
+        threading.Thread(target=self.serve, kwargs=dict(config=self.config), daemon=True).start()
 

--- a/pyouroboros/webhook.py
+++ b/pyouroboros/webhook.py
@@ -1,0 +1,28 @@
+from bottle import Bottle
+
+from logging import getLogger
+import threading
+
+
+class HookManager(object):
+    def __init__(self, config, modes, scheduler):
+        self.config = config
+        self.logger = getLogger()
+        if not config.webhook:
+            return
+        self.modes = modes
+        self.scheduler = scheduler
+
+        self._app = Bottle()
+        self._route()
+
+        threading.Thread(target=self._app.run, kwargs=dict(host=self.config.webhook_addr, port=self.config.webhook_port), daemon=True).start()
+
+    def _route(self):
+        self._app.route('/update', method="POST", callback=self._index)
+
+    def _index(self):
+        for mode in self.modes:
+            self.scheduler.add_job(mode.update, name=f'Webhook triggered update for {mode.socket}')
+        return 'updated'
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests>=2.21.0
 influxdb>=5.2.1
 apprise>=0.8.2
 apscheduler>=3.5.3
+bottle>=0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ requests>=2.21.0
 influxdb>=5.2.1
 apprise>=0.8.2
 apscheduler>=3.5.3
-bottle>=0.12


### PR DESCRIPTION
I have a setup, where CI jobs build images and push them to a registry. For a timely deployment to production, I used ouroboros with a 10 minute interval. This is unsatisfactory. I prefer triggering a refresh after a successful CI job.
Currently there exists only one endpoint: `POST http://<host>:<port>/update` but if the feature is more widely useful, I imagine having filters to only look for updates of specific images (the ones updated by CI) or docker sockets.