### PR TITLE
bug fix on containers pointing to the same image id

### DIFF
--- a/pyouroboros/dockerclient.py
+++ b/pyouroboros/dockerclient.py
@@ -252,14 +252,12 @@ class Container(BaseImageObject):
         for container in self.monitored:
             current_image = container.image
             current_tag = container.attrs['Config']['Image']
-            shared_image = [uct for uct in updateable if uct[1].id == current_image.id]
-            if shared_image:
-                latest_image = shared_image[0][2]
-            else:
-                try:
-                    latest_image = self.pull(current_tag)
-                except ConnectionError:
-                    continue
+
+            try:
+                latest_image = self.pull(current_tag)
+            except ConnectionError:
+                continue
+
             try:
                 if current_image.id != latest_image.id:
                     updateable.append((container, current_image, latest_image))


### PR DESCRIPTION
The bug is where two containers are pointing to different tags ('latest', 'v1'), which are in turn pointing to the same image id.
After an update ('latest' now points to a new image id), BOTH containers would be updated, instead of only the one ('latest').
the fact that two containers are using the same image id _right now_ does not mean they use the same image _tag_.