### PR TITLE
Preserve original container's image tag

### DIFF
--- a/pyouroboros/helpers.py
+++ b/pyouroboros/helpers.py
@@ -14,7 +14,7 @@ def set_properties(old, new, self_name=None):
             v for v in old.attrs['Config']['Volumes'].keys()
         ],
         'working_dir': old.attrs['Config']['WorkingDir'],
-        'image': new.tags[0],
+        'image': old.attrs['Config']['Image'],
         'command': old.attrs['Config']['Cmd'],
         'host_config': old.attrs['HostConfig'],
         'labels': old.attrs['Config']['Labels'],


### PR DESCRIPTION
It seems that my previous fix was not enough (maybe even redundant?) - 
The/Another reason why the image tag would flip is because it was acquired from tags given to the new image.
Again, a single image could have several tags, and there's no reason to prefer the first. Also tags can be assigned to an already existing image. Tags are essentially pointers.

I am currently verifying this resolve the issue.