### PR TITLE
Remove f string with no f

### DIFF
--- a/pyouroboros/notifiers.py
+++ b/pyouroboros/notifiers.py
@@ -35,7 +35,7 @@ class NotificationManager(object):
     def send(self, container_tuples=None, socket=None, kind='update', next_run=None, mode='container'):
         if kind == 'startup':
             now = datetime.now(timezone.utc).astimezone()
-            title = f'Ouroboros has started'
+            title = 'Ouroboros has started'
             body_fields = [
                 f'Host: {self.config.hostname}',
                 f'Time: {now.strftime("%Y-%m-%d %H:%M:%S")}',


### PR DESCRIPTION
Make flake8 happier by removing the f from the f string with no f'd parts. :)

This should allow CI to pass so future dependabot updates (like #405, #406, #407) will be easier to merge, preventing the project from falling behind security updates.